### PR TITLE
fixed documentation of --use_cpu CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python eval.py -i /path/to/audio_directory -o /path/to/output
 
 
 ```bash
-python eval.py -i /path/to/audio.wav -o /path/to/output --use_cpu
+python eval.py -i /path/to/audio.wav -o /path/to/output --use_cpu True
 ```
 
 


### PR DESCRIPTION
`--use_cpu` alone produces an error:

```python
$ python eval.py -i ~/Had_Some_Help.mp3 -o outputs/ --use_cpu
usage: eval.py [-h] -i INPUT_PATH -o OUTPUT_DIR [--use_cpu USE_CPU]
eval.py: error: argument --use_cpu: expected one argument
```

The correct syntax should have a "True" argument as proposed here.